### PR TITLE
Open VSCode URLs now open remote directory  with `--remote`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.1.1
+
+- `Open in VSCode` button now opens remote directories correctly.
+
 ## Version 1.1.0
 
 - Added support for authentication. Can now run with:

--- a/frontend/src/components/Results/UserResult.vue
+++ b/frontend/src/components/Results/UserResult.vue
@@ -67,7 +67,7 @@
             class="ma-2"
             target="_blank"
             :disabled="!result || !result.path"
-            :href="'vscode://file/'+dirPath"
+            :href="vscodeUrl"
           > 
             Open in VSCode 
           </v-btn>
@@ -183,6 +183,18 @@
       dirPath() {
         if (!this.result || !this.result.path) return "";
         return this.result.path
+      },
+      vscodeUrl() {
+        if (!this.result || !this.result.path) return "";
+        let prefix = 'vscode://';
+        if (this.result.host) {
+          prefix = prefix + 'vscode-remote/ssh-remote+' + this.result.host;
+        } else {
+          prefix = prefix + 'file'
+        }
+        const url = prefix + this.result.path;
+        // console.log("VSCode URL is:", url);
+        return url;
       }
     },
     methods: {
@@ -199,6 +211,7 @@
         this.result.path = res.path;
         this.result.marked = res.marked;
         this.result.message = res.message;
+        this.result.host = res.host;
         this.loading = false;
       },
       refreshResults() {

--- a/marker_web/__main__.py
+++ b/marker_web/__main__.py
@@ -32,7 +32,8 @@ def main():
 
     # Run on remote machine
     if args["remote"] is not None:
-        cmd = f"ssh -t -t -L {PORT}:localhost:{PORT} {args['remote']} marker-web -p {PORT} -a"
+        host = args['remote']
+        cmd = f"ssh -t -t -L {PORT}:localhost:{PORT} {host} MARKER_HOST={host} marker-web -p {PORT} -a"
         if verbose:
             cmd += " -v"
 
@@ -49,7 +50,7 @@ def main():
 
     if args["auth"]:
         token = generate_auth_token(32)
-        print(""*80)
+        print("-"*80)
         print("Generated token: ", token)
         print("-"*80)
         print(f"Running at: http://localhost:{PORT}/#/?auth={token}")

--- a/marker_web/marker_server/routes.py
+++ b/marker_web/marker_server/routes.py
@@ -17,6 +17,7 @@ markerBP = Blueprint('marker', __name__)
 
 MARKER = None
 ARGS = {}
+HOSTNAME = os.environ.get('MARKER_HOST', None)
 
 ###############################################################################
 
@@ -107,18 +108,18 @@ def route_single_result(student_id):
         }
         return student_result
 
+    student_result = { 
+        "path": os.path.abspath(student_dir),
+        "host": HOSTNAME,
+    }
+    
     json_path = f'{student_dir}/{MARKER.cfg["results"]}'
     if not os.path.isfile(json_path):
-        student_result = { 
-            "marked": False, 
-            "message": "Submission is not marked yet.",
-            "path": os.path.abspath(student_dir),
-        }
+        student_result["marked"] = False
+        student_result["message"] = "Submission is not marked yet.",
         return student_result
         
-    student_result = {}
     # Add the directory onto the result so we can open up vscode :^)
-    student_result["path"] = os.path.abspath(student_dir)
     student_result["marked"] = True
     student_result["data"] = open(json_path).read()
     return student_result

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name='marker-web',
-    version='1.1.0',
+    version='1.1.1',
     entry_points={
     'console_scripts': [
             'marker-web = marker_web.__main__:main',


### PR DESCRIPTION
When running with `--remote`, the marker sets the `MARKER_HOST`
environment variable on the host machine before running the server.
The server now checks for this environment variable and informs the
frontend about the host (or `None` if local), which then changes
the corresponding URLs for the `Open in VSCode` button to open with
remote SSH. The format for remote URLs is:

```
vscode://vscode-remote/ssh-remote+<ip>/<path-to-file>
```